### PR TITLE
Remove MODULE_TYPELESS_PACKAGE_JSON warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "A lightweight and simple package for i18n and localization for node.js",
 	"main": "build/index.js",
 	"types": "build/index.d.ts",
+	"type": "module",
 	"scripts": {
 		"clean": "rm -rf build && echo 'Done.'",
 		"build": "bun run clean && tsc",


### PR DESCRIPTION
Thanks for your work, I love this lib!

Remove this warning (node v22 / Vite):[MODULE_TYPELESS_PACKAGE_JSON] Warning: file:///Users/my-project/node_modules/i18xs/build/index.js parsed as an ES module because module syntax was detected; to avoid the performance penalty of syntax detection, add "type": "module" to /Users/my-project/node_modules/i18xs/package.json