### PR TITLE
fix: cannot import module in node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { isNodeJS } from './helpers'
+import { isNodeJS } from './helpers/index.js'
 import { Config } from './types/Config'
 import { Localization } from './types/Localization'
 import { LocalizationData } from './types/LocalizationData'


### PR DESCRIPTION
Fixes #2.

I'm able to reproduce this error in another way:
- use `yarn add i18xs` to install I18XS
- import I18XS into my JS file with `import I18XS from 'i18xs'`
- it'll show something like `Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'node_modules/i18xs/build/helpers.js' imported from node_modules/i18xs/build/index.js`